### PR TITLE
Pin GitHub Actions to latest releases with SHA hashes

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,9 +6,9 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-    - uses: rojopolis/spellcheck-github-actions@0.29.0
+    - uses: rojopolis/spellcheck-github-actions@0bf4b2f91efa259b52c202b09b0c3845c524ff36 # 0.58.0
       name: Spellcheck
       with:
         config_path: .github/spellcheck.yml


### PR DESCRIPTION
This PR pins all GitHub Actions to their latest releases using commit SHA hashes for improved security.

## Changes
- **actions/checkout**: Updated from v3 to v6.0.1 (SHA: 8e8c483)
- **rojopolis/spellcheck-github-actions**: Updated from 0.29.0 to 0.58.0 (SHA: 0bf4b2f)

## Benefits
- Pinning to SHA hashes prevents supply chain attacks
- Version comments maintain human readability
- Dependabot can automatically manage and update these pinned versions

## Notes
All actions are pinned to their latest stable releases as of 2026-01-31.